### PR TITLE
Patch for NZD

### DIFF
--- a/www/denominations.json
+++ b/www/denominations.json
@@ -534,6 +534,31 @@
         "wholeSymbol": "RM",
         "wholeSymbolAfter": false
     },
+    "NZD": {
+        "coins": [
+            {"0.10": "copper"},
+            {"0.20": "silver"},
+            {"0.50": "silver"},
+            {"1.00": "gold"},
+            {"2.00": "gold"}
+        ],
+        "fraction": "cent",
+        "fractionSymbol": "c",
+        "fractionSymbolAfter": true,
+        "name": "New Zealand Dollar",
+        "notes": [
+            {"5":    "orange"},
+            {"10":   "blue"},
+            {"20":   "green"},
+            {"50":   "purple"},
+            {"100":  "brown"}
+        ],
+        "pluralName": "New Zealand Dollars",
+        "range": [1, 100],
+        "whole": "dollar",
+        "wholeSymbol": "$",
+        "wholeSymbolAfter": false
+    },
     "PLN": {
         "coins": [
             {"0.01": "copper"},

--- a/www/denominations.json
+++ b/www/denominations.json
@@ -551,7 +551,7 @@
             {"10":   "blue"},
             {"20":   "green"},
             {"50":   "purple"},
-            {"100":  "brown"}
+            {"100":  "red"}
         ],
         "pluralName": "New Zealand Dollars",
         "range": [1, 100],


### PR DESCRIPTION
Added New Zealand Dollar (NZD) to the JSON file.

Sourced the info from Wikipedia:
https://en.wikipedia.org/wiki/New_Zealand_dollar
https://en.wikipedia.org/wiki/Coins_of_the_New_Zealand_dollar#Current_coinage
